### PR TITLE
Create replication user when add a server

### DIFF
--- a/CHANGES_Fabric.txt
+++ b/CHANGES_Fabric.txt
@@ -6,6 +6,7 @@ mikasafabric for MySQL 0.2.2
 -----------------------------
 * Not Filed: CREATE USER replication_user when new server is added
   * Need WITH GRANT OPTION by fabric management user.
+  * Currently, replication_user@very_first_master doesn't create automatically.
 
 mikasafabric for MySQL 0.2.1
 -----------------------------

--- a/CHANGES_Fabric.txt
+++ b/CHANGES_Fabric.txt
@@ -2,6 +2,10 @@
 ChangeLog for Fabric
 ####################
 
+mikasafabric for MySQL 0.2.1
+-----------------------------
+* Not Filed: Change DEFUALT_STATUS SPARE.
+
 mikasafabric for MySQL 0.2.0
 -----------------------------
 * Not Filed: Turn off FailureDetector durning failover/switchover

--- a/CHANGES_Fabric.txt
+++ b/CHANGES_Fabric.txt
@@ -2,6 +2,11 @@
 ChangeLog for Fabric
 ####################
 
+mikasafabric for MySQL 0.2.2
+-----------------------------
+* Not Filed: CREATE USER replication_user when new server is added
+  * Need WITH GRANT OPTION by fabric management user.
+
 mikasafabric for MySQL 0.2.1
 -----------------------------
 * Not Filed: Change DEFUALT_STATUS SPARE.

--- a/mikasafabric.spec
+++ b/mikasafabric.spec
@@ -9,8 +9,8 @@
 
 Summary:       mikasafabric for MySQL is patched MySQL Fabric by GMO Media, Inc.
 Name:          mikasafabric
-Version:       0.2.1
-Release:       20%{?dist}
+Version:       0.2.2
+Release:       1%{?dist}
 License:       GPLv2
 Group:         Development/Libraries
 URL:           https://github.com/gmo-media/mikasafabric

--- a/mikasafabric.spec
+++ b/mikasafabric.spec
@@ -9,8 +9,8 @@
 
 Summary:       mikasafabric for MySQL is patched MySQL Fabric by GMO Media, Inc.
 Name:          mikasafabric
-Version:       0.2.0
-Release:       2%{?dist}
+Version:       0.2.1
+Release:       1%{?dist}
 License:       GPLv2
 Group:         Development/Libraries
 URL:           https://github.com/gmo-media/mikasafabric

--- a/mikasafabric.spec
+++ b/mikasafabric.spec
@@ -10,7 +10,7 @@
 Summary:       mikasafabric for MySQL is patched MySQL Fabric by GMO Media, Inc.
 Name:          mikasafabric
 Version:       0.2.1
-Release:       1%{?dist}
+Release:       19%{?dist}
 License:       GPLv2
 Group:         Development/Libraries
 URL:           https://github.com/gmo-media/mikasafabric

--- a/mikasafabric.spec
+++ b/mikasafabric.spec
@@ -10,7 +10,7 @@
 Summary:       mikasafabric for MySQL is patched MySQL Fabric by GMO Media, Inc.
 Name:          mikasafabric
 Version:       0.2.1
-Release:       19%{?dist}
+Release:       20%{?dist}
 License:       GPLv2
 Group:         Development/Libraries
 URL:           https://github.com/gmo-media/mikasafabric

--- a/mysql/fabric/server.py
+++ b/mysql/fabric/server.py
@@ -886,7 +886,7 @@ class MySQLServer(_persistence.Persistable):
     PRIMARY = "PRIMARY"
 
     # Define default status
-    DEFAULT_STATUS = SECONDARY
+    DEFAULT_STATUS = SPARE
 
     # Set of possible statuses.
     SERVER_STATUS = [FAULTY, SPARE, SECONDARY, PRIMARY]

--- a/mysql/fabric/server.py
+++ b/mysql/fabric/server.py
@@ -843,6 +843,14 @@ class MySQLServer(_persistence.Persistable):
         "status != %s ORDER BY group_id, server_address, server_uuid"
         )
 
+    ### Add replication_user to master.
+    CREATE_REPLICATION_USER = (
+        "CREATE USER IF NOT EXISTS %s@%s IDENTIFIED BY %s"
+        )
+    GRANT_REPLICATION_USER = (
+        "GRANT REPLICATION SLAVE ON *.* TO %s@%s"
+        )
+
     #Default weight for the server
     DEFAULT_WEIGHT = 1.0
 
@@ -1085,6 +1093,7 @@ class MySQLServer(_persistence.Persistable):
         required_level = level or "*.*"
         all_privileges = "ALL PRIVILEGES"
         all_level = "*.*"
+        require_grant_option = True
 
         # Log user name with host name, as it is seen by the server.
         ret = self.exec_stmt("SELECT CURRENT_USER()")
@@ -1094,7 +1103,8 @@ class MySQLServer(_persistence.Persistable):
                        current_user)
 
         ret = self.exec_stmt("SHOW GRANTS")
-        check = re.compile("GRANT (?P<privileges>.*?) ON (?P<level>.*?) TO")
+        check = re.compile("GRANT (?P<privileges>.*?) ON (?P<level>.*?) TO ")
+        grant_option = re.compile(".* WITH GRANT OPTION")
         for row in ret:
             _LOGGER.debug("Row: %s", row[0])
             res = check.match(row[0])
@@ -1104,10 +1114,16 @@ class MySQLServer(_persistence.Persistable):
                 ]
                 level = res.group("level").replace('`', "")
                 if (all_privileges in privileges and all_level == level) or \
-                    ((all_privileges in privileges or required_privileges.issubset(set(privileges))) and \
-                    required_level == level):
-                    _LOGGER.debug("match")
-                    return True
+                   ((all_privileges in privileges or \
+                     required_privileges.issubset(set(privileges))) and \
+                     required_level == level):
+                    _LOGGER.debug("match %s on %s", privileges, level)
+
+                    if require_grant_option:
+                        _LOGGER.critical("grant_option: %s -- %s", grant_option.match(row[0]), row[0])
+                        return True if grant_option.match(row[0]) else False
+                    else:
+                        return True
         _LOGGER.debug("no match")
         return False
 

--- a/mysql/fabric/server.py
+++ b/mysql/fabric/server.py
@@ -845,7 +845,7 @@ class MySQLServer(_persistence.Persistable):
 
     ### Add replication_user to master.
     CREATE_REPLICATION_USER = (
-        "CREATE USER IF NOT EXISTS %s@%s IDENTIFIED BY %s"
+        "CREATE USER /*!50708 IF NOT EXISTS */ %s@%s IDENTIFIED BY %s"
         )
     GRANT_REPLICATION_USER = (
         "GRANT REPLICATION SLAVE ON *.* TO %s@%s"

--- a/mysql/fabric/services/server.py
+++ b/mysql/fabric/services/server.py
@@ -1110,6 +1110,12 @@ def _configure_as_slave(group, server):
         if group.master:
             master = _server.MySQLServer.fetch(group.master)
             master.connect()
+            host, port = split_host_port(server.address)
+            master.exec_stmt(_server.MySQLServer.CREATE_REPLICATION_USER,
+                             {"params": (server.repl_user, host,
+                                         server.repl_pass,)})
+            master.exec_stmt(_server.MySQLServer.GRANT_REPLICATION_USER,
+                             {"params": (server.repl_user, host,)})
             _services_utils.switch_master(server, master)
     except _errors.DatabaseError as error:
         msg = "Error trying to configure server ({0}) as slave: {1}.".format(


### PR DESCRIPTION
Execute `CREATE USER /*!50708 IF NOT EXISTS */ replication_user@added_server_ipaddr` when add a new server via `mysqlfabric group add`