### PR TITLE
Add `miaksafabric manage openfds`

### DIFF
--- a/CHANGES_Fabric.txt
+++ b/CHANGES_Fabric.txt
@@ -2,6 +2,12 @@
 ChangeLog for Fabric
 ####################
 
+mikasafabric for MySQL 0.6.7
+-----------------------------
+* Add "mikasafabric manage openfds" for observation mikasafabric's opened fds
+  * See https://github.com/gmo-media/mikasafabric/issues/7
+
+
 mikasafabric for MySQL 0.6.6
 -----------------------------
 * No changes(just bump up version for building issue)

--- a/mikasafabric.spec
+++ b/mikasafabric.spec
@@ -1,6 +1,6 @@
 Summary:       mikasafabric for MySQL is patched MySQL Fabric by GMO Media, Inc.
 Name:          mikasafabric
-Version:       0.6.6
+Version:       0.6.7
 Release:       1%{?dist}
 License:       GPLv2
 Group:         Development/Libraries


### PR DESCRIPTION
For monitoring of #7 , adding new command for monitoring file descriptors.

```
$ mikasafabric manage openfds
Fabric UUID:  5ca1ab1e-a007-feed-f00d-cab3fe13249e
Time-To-Live: 1

current  max
------- ----
     23 1024
```